### PR TITLE
Stop script after redirect

### DIFF
--- a/code/edit.php
+++ b/code/edit.php
@@ -2,7 +2,10 @@
 
 	require_once("opentape_common.php");
 	
-	if (!is_logged_in()) { header("Location: " . $REL_PATH . "code/login.php"); }
+	if (!is_logged_in()) {
+		header("Location: " . $REL_PATH . "code/login.php");
+		exit();
+	}
 	
 	check_cookie();
 	

--- a/code/settings.php
+++ b/code/settings.php
@@ -2,7 +2,10 @@
 
 	include("opentape_common.php");
 	
-	if (!is_logged_in()) { header("Location: " . $REL_PATH . "code/login.php"); }
+	if (!is_logged_in()) {
+		header("Location: " . $REL_PATH . "code/login.php");
+		exit();
+	}
 	
 	check_cookie();
 	

--- a/code/welcome.php
+++ b/code/welcome.php
@@ -4,8 +4,9 @@
 
 	check_cookie();
 
-	if(is_password_set()) { 
+	if(is_password_set()) {
 		header("Location: " . $REL_PATH . "code/login.php");
+		exit();
 	}
 	
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">


### PR DESCRIPTION
To prevent unauthorized access if the client ignores the redirect header, don't execute the rest of the script if the user is not logged in.